### PR TITLE
Update Screenful Package

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "zone.js": "^0.8.14"
   },
   "dependencies": {
-    "screenfull": "^3.3.2"
+    "screenfull": "^4.2.0"
   }
 }


### PR DESCRIPTION
Old dependency gives error : screenfull.js:102 Uncaught (in promise) TypeError: Document not active
    at exit (screenfull.js:102)