### PR TITLE
Minor changes to be properly compiled with `ng build --prod` command in Angular 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # NgxImageViewer
 
-A configurable Angular image viewer component, compatible with Angular 2.x, 4.x and 5.x
+A configurable Angular image viewer component, compatible with Angular 2+
 
 ## Features:
- * Compatible with Angular 2.x, 4.x, 5.x, 6.x, 7.x, 8.x
+ * Compatible with Angular 2+
  * Configurable
  * Rotate image
  * Zoom image

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A configurable Angular image viewer component, compatible with Angular 2.x, 4.x and 5.x
 
 ## Features:
- * Compatible with Angular 2.x, 4.x and 5.x
+ * Compatible with Angular 2.x, 4.x, 5.x, 6.x, 7.x, 8.x
  * Configurable
  * Rotate image
  * Zoom image

--- a/src/app/image-viewer/image-viewer.component.html
+++ b/src/app/image-viewer/image-viewer.component.html
@@ -1,6 +1,6 @@
 <div [ngxToggleFullscreen]="fullscreen" class="img-container" [style.backgroundColor]="config.containerBackgroundColor"
-     (wheel)="scrollZoom($event)" (dragover)="onDragOver($event)">
-  <img [src]="src[index]" [ngStyle]="style" alt="Image not found..." (dragstart)="onDragStart($event)" (load)="onLoad()" (loadstart)="onLoadStart()"/>
+  (wheel)="scrollZoom($event)" (dragover)="onDragOver($event)">
+  <img [src]="src[index]" [ngStyle]="style" alt="Image not found..." (dragstart)="onDragStart($event)" (load)="onLoad()" (loadstart)="onLoadStart()" />
   <!-- Div below will be used to hide the 'ghost' image when dragging -->
   <div></div>
   <div class="spinner-container" *ngIf="loading">
@@ -29,11 +29,11 @@
     <span [class]="config.btnIcons.fullscreen"></span>
   </button>
 
-  <div class="nav-button-container" *ngIf="src.length > 1">
-    <button type="button" [class]="config.btnClass" (click)="prevImage()" [disabled]="index === 0">
+  <div class="nav-button-container" *ngIf="src.length> 1">
+    <button type="button" [class]="config.btnClass" (click)="prevImage($event)" [disabled]="index === 0">
       <span [class]="config.btnIcons.prev"></span>
     </button>
-    <button type="button" [class]="config.btnClass" (click)="nextImage()" [disabled]="index === src.length - 1">
+    <button type="button" [class]="config.btnClass" (click)="nextImage($event)" [disabled]="index === src.length - 1">
       <span [class]="config.btnIcons.next"></span>
     </button>
   </div>

--- a/src/app/image-viewer/image-viewer.component.ts
+++ b/src/app/image-viewer/image-viewer.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, Input, Optional, Inject, Output, EventEmitter, HostListener} from '@angular/core';
+import { Component, OnInit, Input, Optional, Inject, Output, EventEmitter, HostListener } from '@angular/core';
 import { ImageViewerConfig, CustomEvent } from './image-viewer-config.model';
 
 const DEFAULT_CONFIG: ImageViewerConfig = {
@@ -63,7 +63,7 @@ export class ImageViewerComponent implements OnInit {
   private prevY: number;
   private hovered = false;
 
-  constructor( @Optional() @Inject('config') public moduleConfig: ImageViewerConfig) { }
+  constructor(@Optional() @Inject('config') public moduleConfig: ImageViewerConfig) { }
 
   ngOnInit() {
     const merged = this.mergeConfig(DEFAULT_CONFIG, this.moduleConfig);
@@ -71,7 +71,7 @@ export class ImageViewerComponent implements OnInit {
     this.triggerConfigBinding();
   }
 
-  @HostListener('window:keyup.ArrowRight',  ['$event'])
+  @HostListener('window:keyup.ArrowRight', ['$event'])
   nextImage(event) {
     if (this.canNavigate(event) && this.index < this.src.length - 1) {
       this.loading = true;
@@ -172,17 +172,17 @@ export class ImageViewerComponent implements OnInit {
   }
 
   @HostListener('mouseover')
-  private onMouseOver() {
+  onMouseOver() {
     this.hovered = true;
   }
 
   @HostListener('mouseleave')
-  private onMouseLeave() {
+  onMouseLeave() {
     this.hovered = false;
   }
 
   private canNavigate(event: any) {
-    return event == null ||  (this.config.allowKeyboardNavigation && this.hovered);
+    return event == null || (this.config.allowKeyboardNavigation && this.hovered);
   }
 
   private updateStyle() {


### PR DESCRIPTION
We are developing a project with Angular 8, and we used this module as image carousel, but when we tried to compile it under production environment (_ng build --prod_), we have no able to finish the process due to some syntax errors like:

- _onMouseOver()_ and _onMouseLeave()_ methods become to **public**, instead of private.
- _prevImage()_ and _nextImage()_ called from image-viewer.component.html file, become to **prevImage($event)** and **nextImage($event)**, because of building process were failing if you did not pass any argument to these methods, which are trying to handle one (_event_) in the code.

Hope you may wish to consider these minimal changes for improving this awesome module.